### PR TITLE
A fix for the location of the logofile.

### DIFF
--- a/diamond/bin/diamond
+++ b/diamond/bin/diamond
@@ -113,7 +113,7 @@ def main():
   for possible_logofile in [os.path.join(diamond_path, "gui", "diamond.svg"), 
                             os.path.join(diamond_path, "share", "diamond", "gui", "diamond.svg"),
                             "/usr/share/diamond/gui/diamond.svg",
-                            os.path.join(diamond_path, "gui", "diamond.png"),]:
+                            os.path.join(diamond_path, "gui", "diamond.png"),
                             os.path.join(diamond_path, "share", "diamond", "gui", "diamond.png"),]:
     try:
       os.stat(possible_logofile)

--- a/diamond/bin/diamond
+++ b/diamond/bin/diamond
@@ -111,8 +111,10 @@ def main():
 
   logofile = None
   for possible_logofile in [os.path.join(diamond_path, "gui", "diamond.svg"), 
+                            os.path.join(diamond_path, "share", "diamond", "gui", "diamond.svg"),
                             "/usr/share/diamond/gui/diamond.svg",
                             os.path.join(diamond_path, "gui", "diamond.png"),]:
+                            os.path.join(diamond_path, "share", "diamond", "gui", "diamond.png"),]:
     try:
       os.stat(possible_logofile)
       if logofile == None:


### PR DESCRIPTION
If you've only installed from source and have multiple available schema files then you'll get an error when trying to open the schema decision radio dialog.  This is because the logofile is None but referenced as if it were a list (logofile[0]).  This adds the path of the source-installed logofile to the list of possible search directories.