### PR TITLE
Add CI via AMCG Jenkins server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,54 @@
+pipeline {
+
+    agent { 
+        docker {
+	    image 'fluidity/baseimages:xenial'
+            label 'azure-linux-2core'
+        } 
+    }
+    environment {
+        OMPI_MCA_btl = '^openib'
+    }
+    stages {
+        stage('Configuring') {   
+            steps { 
+                slackSend "Build started - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
+                sh './configure --prefix=\$HOME' 
+            }
+        }    
+        stage('Building') {       
+            steps { 
+                sh 'make -j'
+                sh 'make doc'
+		sh 'make install'
+            }
+        }
+        stage('Testing') {       
+            steps { 
+                sh 'make junittest' ;
+                junit 'src/tests/test_result*xml'
+            }
+        }
+    }
+    post {
+        aborted {
+            slackSend(color: '#DEADED',
+	              message: "Build aborted - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+        }
+	success {
+	    slackSend (color: 'good',
+	     message: "Build completed successfully - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+        }
+	unstable {
+	    slackSend(color: 'warning',
+	              message: "Build completed with test failures - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+            script {
+                currentBuild.result = "FAILURE"
+            }
+        }
+	failure {
+	    slackSend(color: 'danger',
+	              message: "Build failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,17 +16,44 @@ pipeline {
                 sh './configure --prefix=\$HOME' 
             }
         }    
-        stage('Building') {       
+        stage('Building for python2') {       
             steps { 
                 sh 'make -j'
                 sh 'make doc'
 		sh 'make install'
             }
         }
-        stage('Testing') {       
+	stage('Testing fortran library') {
             steps { 
                 sh 'make junittest' ;
                 junit 'src/tests/test_result*xml'
+            }
+	}
+        stage('Testing for python2') {       
+            steps { 
+	        withEnv(['PYTHONPATH=/home/fluidity/lib/python2.7/site-packages',
+		         'LD_LIBRARY_PATH=/home/fluidity/lib']) {
+		    sh 'cd python; python2 test_libspud_junit.py' 
+                }
+                junit 'python/test_result*xml'
+		sh 'rm python/test_result*xml'
+            }
+        }
+/*	stage('Building for python3') {       
+            steps { 
+		sh 'cd python; python3 setup.py install; cd ..'
+            }
+        }
+	stage('Testing for python3') {       
+            steps { 
+		sh 'cd python; python3 test_libspud_junit.py' 
+                junit 'python/test_result*xml'
+		sh 'rm python/test_result*xml'
+            }
+        } */
+	stage('Building documentation') {       
+            steps { 
+		sh 'make doc'
             }
         }
     }

--- a/Makefile.in
+++ b/Makefile.in
@@ -66,6 +66,9 @@ test: unittest
 unittest: libspud.la
 	@cd src/tests; $(MAKE)
 
+junittest: libspud.la
+	@cd src/tests; $(MAKE) junittest
+
 .PHONY:doc
 
 doc: 

--- a/python/test_libspud_junit.py
+++ b/python/test_libspud_junit.py
@@ -1,0 +1,131 @@
+import os
+import libspud
+
+from junit_xml import TestSuite, TestCase
+
+suite = TestSuite('libspud for python',[])
+
+dirpath = os.path.dirname(os.path.abspath(__file__))
+
+def test(test_str, exception=None):
+    """ Pass/fail test."""
+    suite.test_cases.append(TestCase('libspud for python.%s'%test_str))    
+    try:
+        result = eval(test_str)
+        if not result:
+             suite.test_cases[-1].add_failure_info('Failure')
+    except Exception as e:
+        suite.test_cases[-1].add_failure_info('Exception', str(e))
+
+def exception_test(test_str, exception):
+    """Test should throw exception."""
+    try:
+        suite.test_cases.append(TestCase("%s fails"%test_str))
+        eval(test_str)
+        suite.test_cases[-1].add_failure_info('No exception')
+    except exception as e:
+        return
+    # reach here on test failure
+    suite.test_cases[-1].add_failure_info('Exception', str(e))
+
+try:
+    suite.test_cases.append(TestCase('libspud for python.load_options'))
+    libspud.load_options(dirpath+'/test.flml')
+except:
+    suite.test_cases[-1].add_failure_info('Exception')
+    with open('test_results.xml', 'w') as handle:
+        suite.to_file(handle, [suite])
+    raise ValueError
+
+test("libspud.get_option('/timestepping/timestep') == 0.025")
+test("libspud.get_number_of_children('/geometry') == 5")
+test("libspud.get_child_name('geometry', 0) == 'dimension'")
+
+test("libspud.option_count('/problem_type') == 1")
+test("libspud.have_option('/problem_type')")
+
+test("libspud.get_option_type('/geometry/dimension') is int")
+test("libspud.get_option_type('/problem_type') is str")
+
+test("libspud.get_option_rank('/geometry/dimension') == 0")
+test("libspud.get_option_rank('/physical_parameters/gravity/vector_field::GravityDirection/prescribed/value/constant') == 1")
+
+test("libspud.get_option_shape('/geometry/dimension') == (-1, -1)")
+test("libspud.get_option_shape('/problem_type')[0] > 1")
+test("libspud.get_option_shape('/problem_type')[1] == -1")
+
+test("libspud.get_option('/problem_type') == 'multimaterial'")
+test("libspud.get_option('/geometry/dimension') == 2")
+libspud.set_option('/geometry/dimension', 3)
+
+
+test("libspud.get_option('/geometry/dimension') == 3")
+
+list_path = '/material_phase::Material1/scalar_field::MaterialVolumeFraction/prognostic/boundary_conditions::LetNoOneLeave/surface_ids'
+test("libspud.get_option_shape(list_path) == (4, -1)")
+test("libspud.get_option_rank(list_path) == 1")
+test("libspud.get_option(list_path) == [7, 8, 9, 10]")
+
+libspud.set_option(list_path, [11, 12, 13, 14, 15])
+test("libspud.get_option_shape(list_path) == (5, -1)")
+test("libspud.get_option_rank(list_path) == 1")
+test("libspud.get_option(list_path)==[11, 12, 13, 14, 15]")
+
+tensor_path = '/material_phase::Material1/tensor_field::DummyTensor/prescribed/value::WholeMesh/anisotropic_asymmetric/constant'
+test("libspud.get_option_shape(tensor_path) == (2, 2)")
+test("libspud.get_option_rank(tensor_path) == 2")
+
+test("libspud.get_option(tensor_path)==[[1.0,2.0],[3.0,4.0]]")
+
+libspud.set_option(tensor_path, [[5.0,6.0,2.0],[7.0,8.0,1.0]])
+test("libspud.get_option_shape(tensor_path) == (2,3)")
+test("libspud.get_option_rank(tensor_path) == 2")
+
+test("libspud.get_option(tensor_path)==[[5.0, 6.0, 2.0],[7.0, 8.0, 1.0]]")
+
+exception_test("libspud.add_option('/foo')", libspud.SpudNewKeyWarning)
+
+test("libspud.option_count('/foo') == 1")
+
+libspud.set_option('/problem_type', 'helloworld')
+test("libspud.get_option('/problem_type') == 'helloworld'")
+
+exception_test("libspud.set_option_attribute('/foo/bar', 'foobar')", libspud.SpudNewKeyWarning)
+
+test("libspud.get_option('/foo/bar') == 'foobar'")
+  
+libspud.delete_option('/foo')
+test("libspud.option_count('/foo') == 0")
+
+exception_test("libspud.get_option('/foo')", libspud.SpudKeyError)
+exception_test("libspud.get_option('/geometry')", libspud.SpudTypeError)
+
+libspud.write_options(dirpath+'test_out.flml')
+
+exception_test("libspud.set_option('/test', 4.3)", libspud.SpudNewKeyWarning)
+test("libspud.get_option('/test') == 4.3")
+test("libspud.set_option('/test',4) or True")
+
+test("libspud.get_option('/test') == 4")
+
+libspud.set_option('/test',[[4.0,2.0,3.0],[2.0,5.0,6.6]]) 
+
+test("libspud.get_option('/test') == [[4.0,2.0,3.0],[2.0,5.0,6.6]]")
+
+libspud.set_option('/test',"Hallo")
+
+test("libspud.get_option('/test') == 'Hallo'")
+
+libspud.set_option('/test',[1,2,3])
+
+test("libspud.get_option('/test') == [1,2,3]")
+
+libspud.set_option('/test',[2.3,3.3])
+
+test("libspud.get_option('/test') == [2.3,3.3]")
+
+exception_test("libspud.set_option('/test')", libspud.SpudError)
+
+  
+with open(os.path.dirname(os.path.abspath(__file__))+'/test_results.xml', 'w') as handle:
+    suite.to_file(handle, [suite])

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -47,6 +47,9 @@ test-binaries: $(TEST_BINARIES)
 unittest: test-binaries
 	@PATH=.:$PATH; $(TEST_BINARIES)
 
+junittest: test-binaries
+	./junit_test.py
+
 .SUFFIXES: .f90 .F90 .c .cpp .o .a $(.SUFFIXES)
 
 %.o:	%.f90

--- a/src/tests/junit_test.py
+++ b/src/tests/junit_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import glob
+import subprocess
+import os
+
+from junit_xml import TestSuite, TestCase
+
+tests = glob.glob('bin/*')
+
+suites = []
+
+for test in tests:
+    output = subprocess.check_output(os.path.abspath(test)) 
+    title = ''
+    for line in output.split('\n'):
+        if not line.strip():
+            continue
+        if line[1:4]=='***':
+            title = line.replace('***','').strip()
+            suites.append(TestSuite('%s'%title,[]))
+        else:
+            result, name = [part.strip() for part in line.split(':',1)]
+            result = result == 'Pass'
+            if not result:
+                name, error = name.split(';')
+            name = name[1:-1]
+            suites[-1].test_cases.append(TestCase( name, '%s.%s'%(title, name)))
+            if not result:
+                suites[-1].test_cases[-1].add_failure_info('Fail', error)
+
+with open('test_results.xml', 'w') as handle:
+    suites[-1].to_file(handle, suites)
+        
+


### PR DESCRIPTION
This changeset exercises the spud tests via the AMCG Jenkins server at https://jenkins.ese.ic.ac.uk:8000/job/Spud. It runs the existing Fortran and python tests. It's currently limited to python2, but with #3 can be extended to python3.