### PR TITLE
Change MPI C++ to C bindings.

### DIFF
--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -38,12 +38,12 @@ extern "C"{
 
 int main(int argc, char **argv) {
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   chdir(getenv("PWD"));
 #endif
   TESTNAME();
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;


### PR DESCRIPTION
The C++ bindings are deprecated and dropped in the MPI-3 standard. This was fixed already in fluidity but effectively reverted as fluidity is now directly pulling in from spud master with subtree. So fixing again now upstream, so it can be pulled back into fluidity.