### PR TITLE
Make spud-set compatible with python 3

### DIFF
--- a/bin/spud-set
+++ b/bin/spud-set
@@ -36,8 +36,8 @@ path = re.sub(pattern, r'[@name="\1"]/', path)
 node = tree.xpath(path)[0]
 
 # Now we need to find the <real_value> or <integer_value> etc. tag underneath it.
-child = filter(not_comment, node.getchildren())[0]
+child = list(filter(not_comment, node.getchildren()))[0]
 child.text = newval
 
-newfile = open(sys.argv[1], "w")
+newfile = open(sys.argv[1], "wb")
 tree.write(newfile, encoding="utf-8", xml_declaration=True)


### PR DESCRIPTION
2 small changes: explicitly convert a filter generator to a list, and explicitly open the new file in binary mode so that forcing a utf-8 write works.