### PR TITLE
Fix for GtkSource 4 in Ubuntu 20.04 and later

### DIFF
--- a/diamond/bin/diamond
+++ b/diamond/bin/diamond
@@ -23,8 +23,14 @@ import traceback
 import string
 
 import gi
+
 gi.require_version('Gtk', '3.0')
-gi.require_version('GtkSource', '3.0')
+
+try:
+  gi.require_version('GtkSource', '4')
+except:
+  gi.require_version('GtkSource', '3.0')
+
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 

--- a/diamond/bin/diamond
+++ b/diamond/bin/diamond
@@ -27,7 +27,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 
 try:
-  gi.require_version('GtkSource', '4.0')
+  gi.require_version('GtkSource', '4')
 except ValueError:
   gi.require_version('GtkSource', '3.0')
 

--- a/diamond/bin/diamond
+++ b/diamond/bin/diamond
@@ -27,8 +27,8 @@ import gi
 gi.require_version('Gtk', '3.0')
 
 try:
-  gi.require_version('GtkSource', '4')
-except:
+  gi.require_version('GtkSource', '4.0')
+except ValueError:
   gi.require_version('GtkSource', '3.0')
 
 from gi.repository import Gtk as gtk


### PR DESCRIPTION
Fix for GtkSource v4 as present in Ubuntu 20.04 and later, contributed by Pablo Salinas, with backward compatibility for v3 as still present in 18.04.