### PR TITLE
Changes required for Noble

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+spud (1.2.2) UNRELEASED; urgency=medium
+
+  * fixes for diamond and python libspud with python 3.12
+
+ -- Stephan Kramer <s.kramer@imperial.ac.uk>  Fri, 07 Nov 2025 16:36:21 +0000
+
 spud (1.2.1) noble; urgency=medium
 
   * noble build: fix issue with lingering .pybuild/ dir

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+spud (1.2.1) noble; urgency=medium
+
+  * noble build: fix issue with lingering .pybuild/ dir
+
+ -- Stephan Kramer <s.kramer@imperial.ac.uk>  Sat, 17 Aug 2024 15:18:51 +0100
+
 spud (1.2) UNRELEASED; urgency=medium
 
   * Rewrite Debian/Ubuntu packaging

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-#export DH_VERBOSE=1
+export DH_VERBOSE=1
 export BUILDING_DEBIAN=yes
 PYTHON_DIRS=diamond dxdiff python
 
@@ -13,6 +13,7 @@ PYTHON_DIRS=diamond dxdiff python
 override_dh_auto_build:
 	dh_auto_build -- libspud.la
 	for i in $(PYTHON_DIRS); do PYBUILD_NAME=$$i; dh_auto_build --buildsystem=pybuild --sourcedir=$$i; done
+	rm -rf .pybuild/  # this should have been removed by pybuild, but doesn't https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1056291
 
 # instead of a single "make install" into debian/tmp
 # only use makefile for install-libspud and install-spudtools
@@ -20,3 +21,4 @@ override_dh_auto_build:
 override_dh_auto_install:
 	make install-libspud install-spudtools DESTDIR=debian/tmp/
 	for i in $(PYTHON_DIRS); do PYBUILD_NAME=$$i; dh_auto_install --buildsystem=pybuild --sourcedir=$$i; done
+	rm -rf .pybuild/  # this should have been removed by pybuild, but doesn't https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1056291

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DH_VERBOSE=1
+#export DH_VERBOSE=1
 export BUILDING_DEBIAN=yes
 PYTHON_DIRS=diamond dxdiff python
 

--- a/diamond/diamond/config.py
+++ b/diamond/diamond/config.py
@@ -30,7 +30,7 @@ dirs.append(os.path.join(os.path.expanduser('~'), ".diamond"))
 if "DIAMOND_CONFIG_PATH" in os.environ:
   dirs += reversed(os.environ["DIAMOND_CONFIG_PATH"].split(":"))
 
-config = configparser.SafeConfigParser()
+config = configparser.ConfigParser()
 config.read([os.path.join(path, "settings") for path in reversed(dirs)]) #reversed to load usr last
 
 try:

--- a/diamond/diamond/preprocess.py.in
+++ b/diamond/diamond/preprocess.py.in
@@ -22,8 +22,6 @@ from . import debug
 import sys
 import copy
 
-from future.standard_library import install_aliases
-install_aliases()
 import urllib.request, urllib.error, urllib.parse
 
 def preprocess(schemafile):

--- a/diamond/diamond/scherror.py
+++ b/diamond/diamond/scherror.py
@@ -195,7 +195,7 @@ class DiamondSchemaError:
     return self.listview.get_property("visible")
 
   def get_elem_name(self, line):
-    xml = re.compile("<([/?!]?\w+)", re.VERBOSE)
+    xml = re.compile(r"<([/?!]?\w+)", re.VERBOSE)
     matches = xml.findall(line)
     return matches[0]
 

--- a/python/libspud.c
+++ b/python/libspud.c
@@ -5,15 +5,6 @@
 
 #define MAXLENGTH   2048
 
-#if PY_MAJOR_VERSION >= 3
-#define PyInt_Type PyLong_Type
-#define PyInt_Check PyLong_Check
-#define PyString_Type PyUnicode_Type
-#define PyString_AsString PyUnicode_AsUTF8
-#define PyString_Check PyUnicode_Check
-#define PyString_GET_SIZE PyUnicode_GET_LENGTH
-#endif
-
 static PyObject *SpudError;
 static PyObject *SpudTypeError;
 static PyObject *SpudKeyError;
@@ -229,15 +220,15 @@ libspud_get_option_type(PyObject *self, PyObject *args)
         return (PyObject*) &PyFloat_Type;
     }
     else if (type == SPUD_INT){
-        Py_INCREF(&PyInt_Type);
-        return (PyObject*) &PyInt_Type;
+        Py_INCREF(&PyLong_Type);
+        return (PyObject*) &PyLong_Type;
     }
     else if (type == SPUD_NONE){
         Py_RETURN_NONE;
     }
     else if (type == SPUD_STRING){
-        Py_INCREF(&PyString_Type);
-        return (PyObject*) &PyString_Type;
+        Py_INCREF(&PyUnicode_Type);
+        return (PyObject*) &PyUnicode_Type;
     }
 
     PyErr_SetString(SpudError,"Error: Get option type function failed");
@@ -562,7 +553,7 @@ set_option_aux_list_doubles(PyObject *pylist, const char *key, int key_len, int 
 static PyObject*
 set_option_aux_string(PyObject *pystring, const char *key, int key_len, int type, int rank, int *shape)
 {   // this function is for setting option when the second argument is of type string
-    const char *val = PyString_AsString(pystring);
+    const char *val = PyUnicode_AsUTF8(pystring);
     int outcomeSetOption = spud_set_option(key, key_len, val, type, rank, shape);
     return error_checking(outcomeSetOption, "set option aux string");
 }
@@ -702,18 +693,16 @@ libspud_set_option(PyObject *self, PyObject *args)
         int outcomeAddOption = spud_add_option(key, key_len);
         error_checking(outcomeAddOption, "set option");
     }
-
-    if (PyInt_Check(secondArg)){ //just an int
+    if (PyLong_Check(secondArg)){ //just an int
         type = SPUD_INT;
         rank = 0;
         shape[0] = -1;
         shape[1] = -1;
-
     }
-    else if (PyString_Check(secondArg)){// a string
+    else if (PyUnicode_Check(secondArg)){// a Unicode string
         type = SPUD_STRING;
         rank = 1;
-        shape[0] = PyString_GET_SIZE(secondArg);
+        shape[0] = PyUnicode_GET_LENGTH(secondArg);
         shape[1] = -1;
     }
     else if (PyFloat_Check(secondArg)){// a double
@@ -724,7 +713,7 @@ libspud_set_option(PyObject *self, PyObject *args)
     }
     else if (PyList_Check(secondArg)){
         PyObject* listElement = PyList_GetItem(secondArg, 0);
-        if (PyInt_Check(listElement)){ //list of ints
+        if (PyLong_Check(listElement)){ //list of ints
             type = SPUD_INT;
             rank = 1;
             shape[0] = 1;
@@ -740,7 +729,7 @@ libspud_set_option(PyObject *self, PyObject *args)
             int pylistSize = PyList_GET_SIZE(secondArg);
             int pysublistSize = PyList_GET_SIZE(listElement);
             PyObject* sublistElement = PyList_GetItem(listElement, 0);
-            if (PyInt_Check(sublistElement)){ //list of lists of ints
+            if (PyLong_Check(sublistElement)){ //list of lists of ints
                 type = SPUD_INT;
             }
             else if (PyFloat_Check(sublistElement)){//list of lists of doubles
@@ -756,7 +745,7 @@ libspud_set_option(PyObject *self, PyObject *args)
         set_option_aux_scalar(secondArg, key, key_len, type, rank, shape);
     }
     else if (rank == 1){ // list or string
-        if (PyString_Check(secondArg)){ // pystring
+        if (PyUnicode_Check(secondArg)){ // pystring
             set_option_aux_string(secondArg, key, key_len, type, rank, shape);
         }
         else if (type == SPUD_INT) { // list of ints


### PR DESCRIPTION
This combines minor Debian package change 1.2.1
with a number of minor fixes to support python 3.12.
The changes in python libspud were required to port fluidity to Noble (and will be backported in its libspud copy)
Changes in diamond appear to give basic functionality in opening diamond with a fluidity schema and setting some options in python 3.12 and 3.13